### PR TITLE
Fix root dir cannot be persisted

### DIFF
--- a/net.sf.eclipse.tomcat/src/net/sf/eclipse/tomcat/TomcatProjectGeneralPropertyPage.java
+++ b/net.sf.eclipse.tomcat/src/net/sf/eclipse/tomcat/TomcatProjectGeneralPropertyPage.java
@@ -310,8 +310,8 @@ public class TomcatProjectGeneralPropertyPage implements TomcatPluginResources {
                 prj.setReloadable(reloadableCheck.getSelection());
                 prj.setRedirectLogger(redirectLoggerCheck.getSelection());
                 prj.setExtraInfo(extraInfoText.getText());
-                prj.setRootDir(getRootDir());
-                prj.setWorkDir(getWorkDir());
+                prj.setRootDir(rootDirText.getText());
+                prj.setWorkDir(workDirText.getText().isEmpty() ? "/work" : workDirText.getText());
                 prj.saveProperties();
             } else {
                 page.getTomcatProject().removeContext();


### PR DESCRIPTION
Related issues: [#36](https://sourceforge.net/p/tomcatplugin/tickets/36/), [#24](https://sourceforge.net/p/tomcatplugin/tickets/24/)

This issue was introduced by [this commit](https://github.com/his-eg/tomcatplugin/commit/10854e71aea3b97a9335894c99c55ae19b1a4f42).

When using `getRootDir()` and `getWorkDir()`, the value of both fields won't be updated anymore. We should read it from the text field instead and make sure that the work dir should have a default value (`/work` in our case) if not specified.

I tested it on my local project, it works well.

cc @nhnb @markuskeunecke 