### PR TITLE
Adding the web.xml 3.1 Schemas to the XML Catalog.

### DIFF
--- a/net.sf.eclipse.tomcat/META-INF/MANIFEST.MF
+++ b/net.sf.eclipse.tomcat/META-INF/MANIFEST.MF
@@ -15,7 +15,8 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.debug.ui,
  org.eclipse.ui.ide,
  org.eclipse.core.variables,
- com.google.guava;bundle-version="15.0.0"
+ com.google.guava;bundle-version="15.0.0",
+ org.eclipse.wst.xml.core
 Bundle-Localization: plugin
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: net.sf.eclipse.tomcat.TomcatLauncherPlugin

--- a/net.sf.eclipse.tomcat/plugin.xml
+++ b/net.sf.eclipse.tomcat/plugin.xml
@@ -234,5 +234,14 @@
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration">
       </key>
    </extension>
+   <extension
+         point="org.eclipse.wst.xml.core.catalogContributions">
+       <catalogContribution id="Tomcat_schema">
+           <public id="webxml_3.1_schema"
+                   publicId="http://xmlns.jcp.org/xml/ns/javaee"
+                   uri="platform:net.sf.eclipse.tomcat/net/sf/eclipse/tomcat/schemas/"
+                   webURL="http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"/>
+       </catalogContribution>
+   </extension>
 
 </plugin>

--- a/net.sf.eclipse.tomcat/src/net/sf/eclipse/tomcat/schemas/javaee_7.xsd
+++ b/net.sf.eclipse.tomcat/src/net/sf/eclipse/tomcat/schemas/javaee_7.xsd
@@ -1,0 +1,3098 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="7">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+      
+      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
+      
+      The contents of this file are subject to the terms of either the GNU
+      General Public License Version 2 only ("GPL") or the Common Development
+      and Distribution License("CDDL") (collectively, the "License").  You
+      may not use this file except in compliance with the License.  You can
+      obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+      or packager/legal/LICENSE.txt.  See the License for the specific
+      language governing permissions and limitations under the License.
+      
+      When distributing the software, include this License Header Notice in each
+      file and include the License file at packager/legal/LICENSE.txt.
+      
+      GPL Classpath Exception:
+      Oracle designates this particular file as subject to the "Classpath"
+      exception as provided by Oracle in the GPL Version 2 section of the License
+      file that accompanied this code.
+      
+      Modifications:
+      If applicable, add the following below the License Header, with the fields
+      enclosed by brackets [] replaced by your own identifying information:
+      "Portions Copyright [year] [name of copyright owner]"
+      
+      Contributor(s):
+      If you wish your version of this file to be governed by only the CDDL or
+      only the GPL Version 2, indicate your decision by adding "[Contributor]
+      elects to include this software in this distribution under the [CDDL or GPL
+      Version 2] license."  If you don't indicate a single choice of license, a
+      recipient has the option to distribute your version of this file under
+      either the CDDL, the GPL Version 2 or to extend the choice of license to
+      its licensees as provided above.  However, if you add GPL Version 2 code
+      and therefore, elected the GPL Version 2 license, then the option applies
+      only if the new code is made subject to such option by the copyright
+      holder.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following definitions that appear in the common
+      shareable schema(s) of Java EE deployment descriptors should be
+      interpreted with respect to the context they are included:
+      
+      Deployment Component may indicate one of the following:
+      java ee application;
+      application client;
+      web application;
+      enterprise bean;
+      resource adapter; 
+      
+      Deployment File may indicate one of the following:
+      ear file;
+      war file;
+      jar file;
+      rar file;
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
+              schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+  <xsd:include schemaLocation="javaee_web_services_client_1_4.xsd"/>
+
+  <xsd:group name="descriptionGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group keeps the usage of the contained description related
+        elements consistent across Java EE deployment descriptors.
+        
+        All elements may occur multiple times with different languages,
+        to support localization of the content.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="display-name"
+                   type="javaee:display-nameType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="icon"
+                   type="javaee:iconType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="jndiEnvironmentRefsGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group keeps the usage of the contained JNDI environment
+        reference elements consistent across Java EE deployment descriptors.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="env-entry"
+                   type="javaee:env-entryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref"
+                   type="javaee:ejb-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-local-ref"
+                   type="javaee:ejb-local-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:group ref="javaee:service-refGroup"/>
+      <xsd:element name="resource-ref"
+                   type="javaee:resource-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref"
+                   type="javaee:resource-env-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref"
+                   type="javaee:message-destination-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-context-ref"
+                   type="javaee:persistence-context-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref"
+                   type="javaee:persistence-unit-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="post-construct"
+                   type="javaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="pre-destroy"
+                   type="javaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="data-source"
+                   type="javaee:data-sourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-connection-factory"
+                   type="javaee:jms-connection-factoryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-destination"
+                   type="javaee:jms-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="mail-session"
+                   type="javaee:mail-sessionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="connection-factory"
+                   type="javaee:connection-factory-resourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="administered-object"
+                   type="javaee:administered-objectType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="resourceGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group collects elements that are common to most
+        JNDI resource elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:resourceBaseGroup"/>
+      <xsd:element name="lookup-name"
+                   type="javaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The JNDI name to be looked up to resolve a resource reference.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="resourceBaseGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group collects elements that are common to all the
+        JNDI resource elements. It does not include the lookup-name
+        element, that is only applicable to some resource elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="mapped-name"
+                   type="javaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A product specific name that this resource should be
+            mapped to.  The name of this resource, as defined by the
+            resource's name element or defaulted, is a name that is
+            local to the application component using the resource.
+            (It's a name in the JNDI java:comp/env namespace.)  Many
+            application servers provide a way to map these local
+            names to names of resources known to the application
+            server.  This mapped name is often a global JNDI name,
+            but may be a name of any form.
+            
+            Application servers are not required to support any
+            particular form or type of mapped name, nor the ability
+            to use mapped names.  The mapped name is
+            product-dependent and often installation-dependent.  No
+            use of a mapped name is portable.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="injection-target"
+                   type="javaee:injection-targetType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="administered-objectType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of an administered object.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this administered object.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            administered object being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The administered object's interface type.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The administered object's class name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="javaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Property of the administered object property.  This may be a 
+            vendor-specific property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="connection-factory-resourceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Connector Connection Factory resource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this resource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            resource being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The fully qualified class name of the connection factory 
+            interface. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transaction-support"
+                   type="javaee:transaction-supportType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The level of transaction support the connection factory 
+            needs to support. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="javaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource property.  This may be a vendor-specific
+            property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="data-sourceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a DataSource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this DataSource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            data source being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            DataSource, XADataSource or ConnectionPoolDataSource
+            implementation class.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="server-name"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Database server name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-number"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Port number where a server is listening for requests.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="database-name"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Name of a database on a server.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="url"
+                   type="javaee:jdbc-urlType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            A JDBC URL. If the <code>url</code> property is specified
+            along with other standard <code>DataSource</code> properties
+            such as <code>serverName</code>, <code>databaseName</code>
+            and <code>portNumber</code>, the more specific properties will
+            take precedence and <code>url</code> will be ignored.
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            User name to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="javaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JDBC DataSource property.  This may be a vendor-specific
+            property or a less commonly used DataSource property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="login-timeout"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Sets the maximum time in seconds that this data source
+            will wait while attempting to connect to a database.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transactional"
+                   type="javaee:xsdBooleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Set to false if connections should not participate in
+            transactions.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="isolation-level"
+                   type="javaee:isolation-levelType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Isolation level for connections.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="initial-pool-size"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Number of connections that should be created when a
+            connection pool is initialized.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-idle-time"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The number of seconds that a physical connection should
+            remain unused in the pool before the connection is
+            closed for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-statements"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The total number of statements that a connection pool
+            should keep open.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="descriptionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The description type is used by a description element to
+        provide text describing the parent element.  The elements
+        that use this type should include any information that the
+        Deployment Component's Deployment File file producer wants
+        to provide to the consumer of the Deployment Component's
+        Deployment File (i.e., to the Deployer). Typically, the
+        tools used by such a Deployment File consumer will display
+        the description when processing the parent element that
+        contains the description.
+        
+        The lang attribute defines the language that the
+        description is provided in. The default value is "en" (English). 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="javaee:xsdStringType">
+        <xsd:attribute ref="xml:lang"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:simpleType name="dewey-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type defines a dewey decimal that is used
+        to describe versions of documents. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="\.?[0-9]+(\.[0-9]+)*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="display-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The display-name type contains a short name that is intended
+        to be displayed by tools. It is used by display-name
+        elements.  The display name need not be unique.
+        
+        Example: 
+        
+        ...
+        <display-name xml:lang="en">
+        Employee Self Service
+        </display-name>
+        
+        The value of the xml:lang attribute is "en" (English) by default. 
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="javaee:string">
+        <xsd:attribute ref="xml:lang"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The ejb-linkType is used by ejb-link
+        elements in the ejb-ref or ejb-local-ref elements to specify
+        that an EJB reference is linked to enterprise bean.
+        
+        The value of the ejb-link element must be the ejb-name of an
+        enterprise bean in the same ejb-jar file or in another ejb-jar
+        file in the same Java EE application unit. 
+        
+        Alternatively, the name in the ejb-link element may be
+        composed of a path name specifying the ejb-jar containing the
+        referenced enterprise bean with the ejb-name of the target
+        bean appended and separated from the path name by "#".  The
+        path name is relative to the Deployment File containing
+        Deployment Component that is referencing the enterprise
+        bean.  This allows multiple enterprise beans with the same
+        ejb-name to be uniquely identified.
+        
+        Examples:
+        
+        <ejb-link>EmployeeRecord</ejb-link>
+        
+        <ejb-link>../products/product.jar#ProductEJB</ejb-link>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-local-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-local-refType is used by ejb-local-ref elements for
+        the declaration of a reference to an enterprise bean's local
+        home or to the local business interface of a 3.0 bean.
+        The declaration consists of:
+        
+        - an optional description
+        - the EJB reference name used in the code of the Deployment 
+        Component that's referencing the enterprise bean.
+        - the optional expected type of the referenced enterprise bean
+        - the optional expected local interface of the referenced 
+        enterprise bean or the local business interface of the 
+        referenced enterprise bean.
+        - the optional expected local home interface of the referenced 
+        enterprise bean. Not applicable if this ejb-local-ref refers
+        to the local business interface of a 3.0 bean.
+        - optional ejb-link information, used to specify the 
+        referenced enterprise bean
+        - optional elements to define injection of the named enterprise  
+        bean into a component field or property.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref-name"
+                   type="javaee:ejb-ref-nameType"/>
+      <xsd:element name="ejb-ref-type"
+                   type="javaee:ejb-ref-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="local-home"
+                   type="javaee:local-homeType"
+                   minOccurs="0"/>
+      <xsd:element name="local"
+                   type="javaee:localType"
+                   minOccurs="0"/>
+      <xsd:element name="ejb-link"
+                   type="javaee:ejb-linkType"
+                   minOccurs="0"/>
+      <xsd:group ref="javaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-ref-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The ejb-ref-name element contains the name of an EJB
+        reference. The EJB reference is an entry in the
+        Deployment Component's environment and is relative to the
+        java:comp/env context.  The name must be unique within the
+        Deployment Component.
+        
+        It is recommended that name is prefixed with "ejb/".
+        
+        Example:
+        
+        <ejb-ref-name>ejb/Payroll</ejb-ref-name>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:jndi-nameType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-refType is used by ejb-ref elements for the
+        declaration of a reference to an enterprise bean's home or
+        to the remote business interface of a 3.0 bean.  
+        The declaration consists of:
+        
+        - an optional description
+        - the EJB reference name used in the code of
+        the Deployment Component that's referencing the enterprise
+        bean. 
+        - the optional expected type of the referenced enterprise bean
+        - the optional remote interface of the referenced enterprise bean
+        or the remote business interface of the referenced enterprise 
+        bean
+        - the optional expected home interface of the referenced 
+        enterprise bean.  Not applicable if this ejb-ref
+        refers to the remote business interface of a 3.0 bean.
+        - optional ejb-link information, used to specify the
+        referenced enterprise bean
+        - optional elements to define injection of the named enterprise
+        bean into a component field or property
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref-name"
+                   type="javaee:ejb-ref-nameType"/>
+      <xsd:element name="ejb-ref-type"
+                   type="javaee:ejb-ref-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="home"
+                   type="javaee:homeType"
+                   minOccurs="0"/>
+      <xsd:element name="remote"
+                   type="javaee:remoteType"
+                   minOccurs="0"/>
+      <xsd:element name="ejb-link"
+                   type="javaee:ejb-linkType"
+                   minOccurs="0"/>
+      <xsd:group ref="javaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-ref-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-ref-typeType contains the expected type of the
+        referenced enterprise bean.
+        
+        The ejb-ref-type designates a value
+        that must be one of the following:
+        
+        Entity
+        Session
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="Entity"/>
+        <xsd:enumeration value="Session"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="emptyType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type is used to designate an empty
+        element when used. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="env-entryType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The env-entryType is used to declare an application's
+        environment entry. The declaration consists of an optional
+        description, the name of the environment entry, a type
+        (optional if the value is injected, otherwise required), and
+        an optional value.
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        If a value is not specified and injection is requested,
+        no injection will occur and no entry of the specified name
+        will be created.  This allows an initial value to be
+        specified in the source code without being incorrectly
+        changed when no override has been specified.
+        
+        If a value is not specified and no injection is requested,
+        a value must be supplied during deployment. 
+        
+        This type is used by env-entry elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="env-entry-name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The env-entry-name element contains the name of a
+            Deployment Component's environment entry.  The name
+            is a JNDI name relative to the java:comp/env
+            context.  The name must be unique within a 
+            Deployment Component. The uniqueness
+            constraints must be defined within the declared
+            context.
+            
+            Example:
+            
+            <env-entry-name>minAmount</env-entry-name>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="env-entry-type"
+                   type="javaee:env-entry-type-valuesType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The env-entry-type element contains the Java language
+            type of the environment entry.  If an injection target
+            is specified for the environment entry, the type may
+            be omitted, or must match the type of the injection
+            target.  If no injection target is specified, the type
+            is required.
+            
+            Example:
+            
+            <env-entry-type>java.lang.Integer</env-entry-type>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="env-entry-value"
+                   type="javaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The env-entry-value designates the value of a
+            Deployment Component's environment entry. The value
+            must be a String that is valid for the
+            constructor of the specified type that takes a
+            single String parameter, or for java.lang.Character,
+            a single character.
+            
+            Example:
+            
+            <env-entry-value>100.00</env-entry-value>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="javaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="env-entry-type-valuesType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        This type contains the fully-qualified Java type of the
+        environment entry value that is expected by the
+        application's code.
+        
+        The following are the legal values of env-entry-type-valuesType:
+        
+        java.lang.Boolean
+        java.lang.Byte
+        java.lang.Character
+        java.lang.String
+        java.lang.Short
+        java.lang.Integer
+        java.lang.Long
+        java.lang.Float
+        java.lang.Double
+        		  java.lang.Class
+        		  any enumeration type (i.e. a subclass of java.lang.Enum)
+        
+        Examples:
+        
+        <env-entry-type>java.lang.Boolean</env-entry-type>
+        <env-entry-type>java.lang.Class</env-entry-type>
+        <env-entry-type>com.example.Color</env-entry-type>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="fully-qualified-classType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The elements that use this type designate the name of a
+        Java class or interface.  The name is in the form of a
+        "binary name", as defined in the JLS.  This is the form
+        of name used in Class.forName().  Tools that need the
+        canonical name (the name used in source code) will need
+        to convert this binary name to the canonical name.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="generic-booleanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type defines four different values which can designate
+        boolean values. This includes values yes and no which are 
+        not designated by xsd:boolean
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="true"/>
+        <xsd:enumeration value="false"/>
+        <xsd:enumeration value="yes"/>
+        <xsd:enumeration value="no"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="iconType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The icon type contains small-icon and large-icon elements
+        that specify the file names for small and large GIF, JPEG,
+        or PNG icon images used to represent the parent element in a
+        GUI tool. 
+        
+        The xml:lang attribute defines the language that the
+        icon file names are provided in. Its value is "en" (English)
+        by default. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="small-icon"
+                   type="javaee:pathType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The small-icon element contains the name of a file
+            containing a small (16 x 16) icon image. The file
+            name is a relative path within the Deployment
+            Component's Deployment File.
+            
+            The image may be in the GIF, JPEG, or PNG format.
+            The icon can be used by tools.
+            
+            Example:
+            
+            <small-icon>employee-service-icon16x16.jpg</small-icon>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="large-icon"
+                   type="javaee:pathType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[[
+            The large-icon element contains the name of a file
+            containing a large
+            (32 x 32) icon image. The file name is a relative 
+            path within the Deployment Component's Deployment
+            File.
+            
+            The image may be in the GIF, JPEG, or PNG format.
+            The icon can be used by tools.
+            
+            Example:
+            
+            <large-icon>employee-service-icon32x32.jpg</large-icon>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute ref="xml:lang"/>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="injection-targetType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        An injection target specifies a class and a name within
+        that class into which a resource should be injected.
+        
+        The injection target class specifies the fully qualified
+        class name that is the target of the injection.  The
+        Java EE specifications describe which classes can be an
+        injection target.
+        
+        The injection target name specifies the target within
+        the specified class.  The target is first looked for as a
+        JavaBeans property name.  If not found, the target is
+        looked for as a field name.
+        
+        The specified resource will be injected into the target
+        during initialization of the class by either calling the
+        set method for the target property or by setting a value
+        into the named field.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="injection-target-class"
+                   type="javaee:fully-qualified-classType"/>
+      <xsd:element name="injection-target-name"
+                   type="javaee:java-identifierType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="isolation-levelType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        	The following transaction isolation levels are allowed
+        	(see documentation for the java.sql.Connection interface):
+        TRANSACTION_READ_UNCOMMITTED
+        TRANSACTION_READ_COMMITTED
+        TRANSACTION_REPEATABLE_READ
+        TRANSACTION_SERIALIZABLE
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="TRANSACTION_READ_UNCOMMITTED"/>
+      <xsd:enumeration value="TRANSACTION_READ_COMMITTED"/>
+      <xsd:enumeration value="TRANSACTION_REPEATABLE_READ"/>
+      <xsd:enumeration value="TRANSACTION_SERIALIZABLE"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="java-identifierType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The java-identifierType defines a Java identifier.
+        The users of this type should further verify that 
+        the content does not contain Java reserved keywords.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:pattern value="($|_|\p{L})(\p{L}|\p{Nd}|_|$)*"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="java-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is a generic type that designates a Java primitive
+        type or a fully qualified name of a Java interface/type,
+        or an array of such types.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:pattern value="[^\p{Z}]*"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jdbc-urlType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The jdbc-urlType contains the url pattern of the mapping.
+        It must follow the rules specified in Section 9.3 of the
+        JDBC Specification where the format is:
+        
+        jdbc:<subprotocol>:<subname>
+        
+        Example:
+        
+        <url>jdbc:mysql://localhost:3307/testdb</url>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:pattern value="jdbc:(.*):(.*)"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jms-connection-factoryType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a JMS Connection Factory.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this JMS Connection Factory.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            JMS connection factory being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the JMS connection factory
+            interface.  Permitted values are javax.jms.ConnectionFactory,
+            javax.jms.QueueConnectionFactory, or 
+            javax.jms.TopicConnectionFactory.  If not specified,
+            javax.jms.ConnectionFactory will be used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the JMS connection factory
+            implementation class.  Ignored if a resource adapter  
+            is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.  If not specified, the application
+            server will define the default behavior, which may or may
+            not involve the use of a resource adapter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            User name to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="client-id"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Client id to use for connection.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="javaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JMS Connection Factory property.  This may be a vendor-specific
+            property or a less commonly used ConnectionFactory property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transactional"
+                   type="javaee:xsdBooleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Set to false if connections should not participate in
+            transactions.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jms-destinationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a JMS Destination.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this JMS Destination.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            JMS destination being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the JMS destination interface.
+            Permitted values are javax.jms.Queue and javax.jms.Topic
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the JMS destination implementation
+            class.  Ignored if a resource adapter is used unless the
+            resource adapter defines more than one destination implementation
+            class for the specified interface.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.  If not specified, the application
+            server will define the default behavior, which may or may
+            not involve the use of a resource adapter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="destination-name"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Name of the queue or topic.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="javaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JMS Destination property.  This may be a vendor-specific
+            property or a less commonly used Destination property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jndi-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The jndi-nameType type designates a JNDI name in the
+        Deployment Component's environment and is relative to the
+        java:comp/env context.  A JNDI name must be unique within the
+        Deployment Component.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="homeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The homeType defines the fully-qualified name of
+        an enterprise bean's home interface. 
+        
+        Example:
+        
+        <home>com.aardvark.payroll.PayrollHome</home>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="lifecycle-callbackType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The lifecycle-callback type specifies a method on a
+        class to be called when a lifecycle event occurs.
+        Note that each class may have only one lifecycle callback
+        method for any given event and that the method may not
+        be overloaded.
+        
+        If the lifefycle-callback-class element is missing then
+        the class defining the callback is assumed to be the
+        component class in scope at the place in the descriptor
+        in which the callback definition appears.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="lifecycle-callback-class"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0"/>
+      <xsd:element name="lifecycle-callback-method"
+                   type="javaee:java-identifierType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="listenerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The listenerType indicates the deployment properties for a web
+        application listener bean.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="listener-class"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The listener-class element declares a class in the
+            application must be registered as a web
+            application listener bean. The value is the fully
+            qualified classname of the listener class.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="localType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The localType defines the fully-qualified name of an
+        enterprise bean's local interface.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="local-homeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The local-homeType defines the fully-qualified
+        name of an enterprise bean's local home interface.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="mail-sessionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Mail Session resource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this Mail Session resource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            Mail Session resource being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="store-protocol"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Storage protocol.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="store-protocol-class"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Service provider store protocol implementation class
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transport-protocol"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Transport protocol.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transport-protocol-class"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Service provider transport protocol implementation class
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="host"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server host name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server user name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="from"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Email address to indicate the message sender.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="javaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server property.  This may be a vendor-specific
+            property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="param-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type is a general type that can be used to declare
+        parameter/value lists.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="param-name"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The param-name element contains the name of a
+            parameter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="param-value"
+                   type="javaee:xsdStringType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The param-value element contains the value of a
+            parameter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="pathType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The elements that use this type designate either a relative
+        path or an absolute path starting with a "/".
+        
+        In elements that specify a pathname to a file within the
+        same Deployment File, relative filenames (i.e., those not
+        starting with "/") are considered relative to the root of
+        the Deployment File's namespace.  Absolute filenames (i.e.,
+        those starting with "/") also specify names in the root of
+        the Deployment File's namespace.  In general, relative names
+        are preferred.  The exception is .war files where absolute
+        names are preferred for consistency with the Servlet API.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The persistence-context-ref element contains a declaration
+        of Deployment Component's reference to a persistence context
+        associated within a Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the persistence context reference name
+        - an optional persistence unit name.  If not specified,
+        the default persistence unit is assumed.
+        - an optional specification as to whether
+        the persistence context type is Transaction or
+        Extended.  If not specified, Transaction is assumed.
+        - an optional specification as to whether
+        the persistence context synchronization with the current
+        transaction is Synchronized or Unsynchronized. If not
+        specified, Synchronized is assumed.
+        - an optional list of persistence properties
+        - optional injection targets
+        
+        Examples:
+        
+        <persistence-context-ref>
+        <persistence-context-ref-name>myPersistenceContext
+        </persistence-context-ref-name>
+        </persistence-context-ref>
+        
+        <persistence-context-ref>
+        <persistence-context-ref-name>myPersistenceContext
+        </persistence-context-ref-name>
+        <persistence-unit-name>PersistenceUnit1
+        </persistence-unit-name>
+        <persistence-context-type>Extended</persistence-context-type>
+        </persistence-context-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-context-ref-name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The persistence-context-ref-name element specifies
+            the name of a persistence context reference; its
+            value is the environment entry name used in
+            Deployment Component code.  The name is a JNDI name
+            relative to the java:comp/env context.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-unit-name"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The Application Assembler(or BeanProvider) may use the
+            following syntax to avoid the need to rename persistence
+            units to have unique names within a Java EE application.
+            
+            The Application Assembler specifies the pathname of the
+            root of the persistence.xml file for the referenced
+            persistence unit and appends the name of the persistence
+            unit separated from the pathname by #. The pathname is
+            relative to the referencing application component jar file. 
+            In this manner, multiple persistence units with the same
+            persistence unit name may be uniquely identified when the 
+            Application Assembler cannot change persistence unit names.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-context-type"
+                   type="javaee:persistence-context-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="persistence-context-synchronization"
+                   type="javaee:persistence-context-synchronizationType"
+                   minOccurs="0"/>
+      <xsd:element name="persistence-property"
+                   type="javaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to specify properties for the container or persistence
+            provider.  Vendor-specific properties may be included in
+            the set of properties.  Properties that are not recognized
+            by a vendor must be ignored.  Entries that make use of the 
+            namespace javax.persistence and its subnamespaces must not
+            be used for vendor-specific properties.  The namespace
+            javax.persistence is reserved for use by the specification.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="javaee:resourceBaseGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-synchronizationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The persistence-context-synchronizationType specifies 
+        whether a container-managed persistence context is automatically
+        synchronized with the current transaction.
+        
+        The value of the persistence-context-synchronization element 
+        must be one of the following:
+        Synchronized
+        Unsynchronized
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="Synchronized"/>
+        <xsd:enumeration value="Unsynchronized"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The persistence-context-typeType specifies the transactional
+        nature of a persistence context reference.  
+        
+        The value of the persistence-context-type element must be
+        one of the following:
+        Transaction
+        Extended
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="Transaction"/>
+        <xsd:enumeration value="Extended"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="propertyType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Specifies a name/value pair.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="javaee:xsdStringType">
+      </xsd:element>
+      <xsd:element name="value"
+                   type="javaee:xsdStringType">
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-unit-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The persistence-unit-ref element contains a declaration
+        of Deployment Component's reference to a persistence unit
+        associated within a Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the persistence unit reference name
+        - an optional persistence unit name.  If not specified,
+        the default persistence unit is assumed.
+        - optional injection targets
+        
+        Examples:
+        
+        <persistence-unit-ref>
+        <persistence-unit-ref-name>myPersistenceUnit
+        </persistence-unit-ref-name>
+        </persistence-unit-ref>
+        
+        <persistence-unit-ref>
+        <persistence-unit-ref-name>myPersistenceUnit
+        </persistence-unit-ref-name>
+        <persistence-unit-name>PersistenceUnit1
+        </persistence-unit-name>
+        </persistence-unit-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref-name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The persistence-unit-ref-name element specifies
+            the name of a persistence unit reference; its
+            value is the environment entry name used in
+            Deployment Component code.  The name is a JNDI name
+            relative to the java:comp/env context.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-unit-name"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The Application Assembler(or BeanProvider) may use the
+            following syntax to avoid the need to rename persistence
+            units to have unique names within a Java EE application.
+            
+            The Application Assembler specifies the pathname of the
+            root of the persistence.xml file for the referenced
+            persistence unit and appends the name of the persistence
+            unit separated from the pathname by #. The pathname is
+            relative to the referencing application component jar file. 
+            In this manner, multiple persistence units with the same
+            persistence unit name may be uniquely identified when the 
+            Application Assembler cannot change persistence unit names.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="javaee:resourceBaseGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="remoteType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The remote element contains the fully-qualified name
+        of the enterprise bean's remote interface.
+        
+        Example:
+        
+        <remote>com.wombat.empl.EmployeeService</remote>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="resource-env-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The resource-env-refType is used to define
+        resource-env-ref elements.  It contains a declaration of a
+        Deployment Component's reference to an administered object
+        associated with a resource in the Deployment Component's
+        environment.  It consists of an optional description, the
+        resource environment reference name, and an optional
+        indication of the resource environment reference type
+        expected by the Deployment Component code.
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        The resource environment type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Example:
+        
+        <resource-env-ref>
+        <resource-env-ref-name>jms/StockQueue
+        </resource-env-ref-name>
+        <resource-env-ref-type>javax.jms.Queue
+        </resource-env-ref-type>
+        </resource-env-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref-name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The resource-env-ref-name element specifies the name
+            of a resource environment reference; its value is
+            the environment entry name used in
+            the Deployment Component code.  The name is a JNDI 
+            name relative to the java:comp/env context and must 
+            be unique within a Deployment Component.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-env-ref-type"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The resource-env-ref-type element specifies the type
+            of a resource environment reference.  It is the
+            fully qualified name of a Java language class or
+            interface.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="javaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="resource-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The resource-refType contains a declaration of a
+        Deployment Component's reference to an external resource. It
+        consists of an optional description, the resource manager
+        connection factory reference name, an optional indication of
+        the resource manager connection factory type expected by the
+        Deployment Component code, an optional type of authentication
+        (Application or Container), and an optional specification of
+        the shareability of connections obtained from the resource
+        (Shareable or Unshareable).
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        The connection factory type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Example:
+        
+        <resource-ref>
+        <res-ref-name>jdbc/EmployeeAppDB</res-ref-name>
+        <res-type>javax.sql.DataSource</res-type>
+        <res-auth>Container</res-auth>
+        <res-sharing-scope>Shareable</res-sharing-scope>
+        </resource-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="res-ref-name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The res-ref-name element specifies the name of a
+            resource manager connection factory reference.
+            The name is a JNDI name relative to the
+            java:comp/env context.  
+            The name must be unique within a Deployment File. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="res-type"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The res-type element specifies the type of the data
+            source. The type is specified by the fully qualified
+            Java language class or interface
+            expected to be implemented by the data source.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="res-auth"
+                   type="javaee:res-authType"
+                   minOccurs="0"/>
+      <xsd:element name="res-sharing-scope"
+                   type="javaee:res-sharing-scopeType"
+                   minOccurs="0"/>
+      <xsd:group ref="javaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="res-authType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The res-authType specifies whether the Deployment Component
+        code signs on programmatically to the resource manager, or
+        whether the Container will sign on to the resource manager
+        on behalf of the Deployment Component. In the latter case,
+        the Container uses information that is supplied by the
+        Deployer.
+        
+        The value must be one of the two following:
+        
+        Application
+        Container
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="Application"/>
+        <xsd:enumeration value="Container"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="res-sharing-scopeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The res-sharing-scope type specifies whether connections
+        obtained through the given resource manager connection
+        factory reference can be shared. The value, if specified,
+        must be one of the two following:
+        
+        Shareable
+        Unshareable
+        
+        The default value is Shareable.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="Shareable"/>
+        <xsd:enumeration value="Unshareable"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="run-asType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The run-asType specifies the run-as identity to be
+        used for the execution of a component. It contains an 
+        optional description, and the name of a security role.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="role-name"
+                   type="javaee:role-nameType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="role-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The role-nameType designates the name of a security role.
+        
+        The name must conform to the lexical rules for a token.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-roleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The security-roleType contains the definition of a security
+        role. The definition consists of an optional description of
+        the security role, and the security role name.
+        
+        Example:
+        
+        <security-role>
+        <description>
+        This role includes all employees who are authorized
+        to access the employee service application.
+        </description>
+        <role-name>employee</role-name>
+        </security-role>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="role-name"
+                   type="javaee:role-nameType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-role-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The security-role-refType contains the declaration of a
+        security role reference in a component's or a
+        Deployment Component's code. The declaration consists of an
+        optional description, the security role name used in the
+        code, and an optional link to a security role. If the
+        security role is not specified, the Deployer must choose an
+        appropriate security role.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="role-name"
+                   type="javaee:role-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The value of the role-name element must be the String used
+            as the parameter to the 
+            EJBContext.isCallerInRole(String roleName) method or the
+            HttpServletRequest.isUserInRole(String role) method.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="role-link"
+                   type="javaee:role-nameType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The role-link element is a reference to a defined
+            security role. The role-link element must contain
+            the name of one of the security roles defined in the
+            security-role elements.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdQNameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:QName.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:QName">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdBooleanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:boolean.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:boolean">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdNMTOKENType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:NMTOKEN.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:NMTOKEN">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdAnyURIType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:anyURI.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:anyURI">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:integer.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:integer">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdPositiveIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:positiveInteger.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:positiveInteger">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdNonNegativeIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:nonNegativeInteger.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:nonNegativeInteger">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdStringType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:string.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="string">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is a special string datatype that is defined by Java EE as
+        a base type for defining collapsed strings. When schemas
+        require trailing/leading space elimination as well as
+        collapsing the existing whitespace, this base type may be
+        used.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:token">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="true-falseType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This simple type designates a boolean with only two
+        permissible values
+        
+        - true
+        - false
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:xsdBooleanType">
+        <xsd:pattern value="(true|false)"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="url-patternType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The url-patternType contains the url pattern of the mapping.
+        It must follow the rules specified in Section 11.2 of the
+        Servlet API Specification. This pattern is assumed to be in
+        URL-decoded form and must not contain CR(#xD) or LF(#xA).
+        If it contains those characters, the container must inform
+        the developer with a descriptive error message.
+        The container must preserve all characters including whitespaces.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destinationType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The message-destinationType specifies a message
+        destination. The logical destination described by this
+        element is mapped to a physical destination by the Deployer.
+        
+        The message destination element contains: 
+        
+        - an optional description
+        - an optional display-name
+        - an optional icon
+        - a message destination name which must be unique
+        among message destination names within the same 
+        Deployment File. 
+        - an optional mapped name
+        - an optional lookup name
+        
+        Example: 
+        
+        <message-destination>
+        <message-destination-name>CorporateStocks
+        </message-destination-name>
+        </message-destination>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="message-destination-name"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The message-destination-name element specifies a
+            name for a message destination.  This name must be
+            unique among the names of message destinations
+            within the Deployment File.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="mapped-name"
+                   type="javaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A product specific name that this message destination
+            should be mapped to.  Each message-destination-ref
+            element that references this message destination will
+            define a name in the namespace of the referencing
+            component or in one of the other predefined namespaces. 
+            Many application servers provide a way to map these
+            local names to names of resources known to the
+            application server.  This mapped name is often a global
+            JNDI name, but may be a name of any form.  Each of the
+            local names should be mapped to this same global name.
+            
+            Application servers are not required to support any
+            particular form or type of mapped name, nor the ability
+            to use mapped names.  The mapped name is
+            product-dependent and often installation-dependent.  No
+            use of a mapped name is portable.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="lookup-name"
+                   type="javaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The JNDI name to be looked up to resolve the message destination.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The message-destination-ref element contains a declaration
+        of Deployment Component's reference to a message destination
+        associated with a resource in Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the message destination reference name
+        - an optional message destination type
+        - an optional specification as to whether
+        the destination is used for 
+        consuming or producing messages, or both.
+        if not specified, "both" is assumed.
+        - an optional link to the message destination
+        - optional injection targets
+        
+        The message destination type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Examples:
+        
+        <message-destination-ref>
+        <message-destination-ref-name>jms/StockQueue
+        </message-destination-ref-name>
+        <message-destination-type>javax.jms.Queue
+        </message-destination-type>
+        <message-destination-usage>Consumes
+        </message-destination-usage>
+        <message-destination-link>CorporateStocks
+        </message-destination-link>
+        </message-destination-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref-name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The message-destination-ref-name element specifies
+            the name of a message destination reference; its
+            value is the environment entry name used in
+            Deployment Component code.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="message-destination-type"
+                   type="javaee:message-destination-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="message-destination-usage"
+                   type="javaee:message-destination-usageType"
+                   minOccurs="0"/>
+      <xsd:element name="message-destination-link"
+                   type="javaee:message-destination-linkType"
+                   minOccurs="0"/>
+      <xsd:group ref="javaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-usageType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The message-destination-usageType specifies the use of the
+        message destination indicated by the reference.  The value
+        indicates whether messages are consumed from the message
+        destination, produced for the destination, or both.  The
+        Assembler makes use of this information in linking producers
+        of a destination with its consumers.
+        
+        The value of the message-destination-usage element must be
+        one of the following:
+        Consumes
+        Produces
+        ConsumesProduces
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="Consumes"/>
+        <xsd:enumeration value="Produces"/>
+        <xsd:enumeration value="ConsumesProduces"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[[
+        The message-destination-typeType specifies the type of
+        the destination. The type is specified by the Java interface
+        expected to be implemented by the destination.
+        
+        Example: 
+        
+        <message-destination-type>javax.jms.Queue
+        </message-destination-type>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The message-destination-linkType is used to link a message
+        destination reference or message-driven bean to a message
+        destination.
+        
+        The Assembler sets the value to reflect the flow of messages
+        between producers and consumers in the application.
+        
+        The value must be the message-destination-name of a message
+        destination in the same Deployment File or in another
+        Deployment File in the same Java EE application unit.
+        
+        Alternatively, the value may be composed of a path name
+        specifying a Deployment File containing the referenced
+        message destination with the message-destination-name of the
+        destination appended and separated from the path name by
+        "#". The path name is relative to the Deployment File
+        containing Deployment Component that is referencing the
+        message destination.  This allows multiple message
+        destinations with the same name to be uniquely identified.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="transaction-supportType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The transaction-supportType specifies the level of
+        transaction support provided by the resource adapter. It is
+        used by transaction-support elements.
+        
+        The value must be one of the following:
+        
+        NoTransaction
+        LocalTransaction
+        XATransaction
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="NoTransaction"/>
+        <xsd:enumeration value="LocalTransaction"/>
+        <xsd:enumeration value="XATransaction"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/net.sf.eclipse.tomcat/src/net/sf/eclipse/tomcat/schemas/javaee_web_services_client_1_4.xsd
+++ b/net.sf.eclipse.tomcat/src/net/sf/eclipse/tomcat/schemas/javaee_web_services_client_1_4.xsd
@@ -1,0 +1,737 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="1.4">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+      
+      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
+      
+      The contents of this file are subject to the terms of either the GNU
+      General Public License Version 2 only ("GPL") or the Common Development
+      and Distribution License("CDDL") (collectively, the "License").  You
+      may not use this file except in compliance with the License.  You can
+      obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+      or packager/legal/LICENSE.txt.  See the License for the specific
+      language governing permissions and limitations under the License.
+      
+      When distributing the software, include this License Header Notice in each
+      file and include the License file at packager/legal/LICENSE.txt.
+      
+      GPL Classpath Exception:
+      Oracle designates this particular file as subject to the "Classpath"
+      exception as provided by Oracle in the GPL Version 2 section of the License
+      file that accompanied this code.
+      
+      Modifications:
+      If applicable, add the following below the License Header, with the fields
+      enclosed by brackets [] replaced by your own identifying information:
+      "Portions Copyright [year] [name of copyright owner]"
+      
+      Contributor(s):
+      If you wish your version of this file to be governed by only the CDDL or
+      only the GPL Version 2, indicate your decision by adding "[Contributor]
+      elects to include this software in this distribution under the [CDDL or GPL
+      Version 2] license."  If you don't indicate a single choice of license, a
+      recipient has the option to distribute your version of this file under
+      either the CDDL, the GPL Version 2 or to extend the choice of license to
+      its licensees as provided above.  However, if you add GPL Version 2 code
+      and therefore, elected the GPL Version 2 license, then the option applies
+      only if the new code is made subject to such option by the copyright
+      holder.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      (C) Copyright International Business Machines Corporation 2002
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="service-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The service-ref element declares a reference to a Web
+        service. It contains optional description, display name and
+        icons, a declaration of the required Service interface,
+        an optional WSDL document location, an optional set
+        of JAX-RPC mappings, an optional QName for the service element,
+        an optional set of Service Endpoint Interfaces to be resolved 
+        by the container to a WSDL port, and an optional set of handlers.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="service-ref-name"
+                   type="javaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-ref-name element declares logical name that the
+            components in the module use to look up the Web service. It 
+            is recommended that all service reference names start with 
+            "service/".
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-interface"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-interface element declares the fully qualified class
+            name of the JAX-RPC Service interface the client depends on. 
+            In most cases the value will be javax.xml.rpc.Service.  A JAX-RPC
+            generated Service Interface class may also be specified.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-ref-type"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-ref-type element declares the type of the service-ref 
+            element that is injected or returned when a JNDI lookup is done.
+            This must be either a fully qualified name of Service class or 
+            the fully qualified name of service endpoint interface class. 
+            This is only used with JAX-WS runtime where the corresponding 
+            @WebServiceRef annotation can be used to denote both a Service
+            or a Port.
+            
+            If this is not specified, then the type of service-ref element 
+            that is injected or returned when a JNDI lookup is done is 
+            always a Service interface/class.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-file"
+                   type="javaee:xsdAnyURIType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The wsdl-file element contains the URI location of a WSDL
+            file. The location is relative to the root of the module.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="jaxrpc-mapping-file"
+                   type="javaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The jaxrpc-mapping-file element contains the name of a file that
+            describes the JAX-RPC mapping between the Java interaces used by
+            the application and the WSDL description in the wsdl-file.  The 
+            file name is a relative path within the module file.
+            
+            This is not required when JAX-WS based runtime is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-qname"
+                   type="javaee:xsdQNameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-qname element declares the specific WSDL service
+            element that is being refered to.  It is not specified if no
+            wsdl-file is declared.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-component-ref"
+                   type="javaee:port-component-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The port-component-ref element declares a client dependency
+            on the container for resolving a Service Endpoint Interface
+            to a WSDL port. It optionally associates the Service Endpoint
+            Interface with a particular port-component. This is only used
+            by the container for a Service.getPort(Class) method call.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:element name="handler"
+                     type="javaee:handlerType"
+                     minOccurs="0"
+                     maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              	Declares the handler for a port-component. Handlers can
+              	access the init-param name/value pairs using the
+              	HandlerInfo interface. If port-name is not specified, the
+              	handler is assumed to be associated with all ports of the
+              	service.
+              
+              	To be used with JAX-RPC based runtime only.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="handler-chains"
+                     type="javaee:handler-chainsType"
+                     minOccurs="0"
+                     maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              	 To be used with JAX-WS based runtime only.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+      <xsd:group ref="javaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="port-component-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The port-component-ref element declares a client dependency
+        on the container for resolving a Service Endpoint Interface
+        to a WSDL port. It optionally associates the Service Endpoint
+        Interface with a particular port-component. This is only used
+        by the container for a Service.getPort(Class) method call.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="service-endpoint-interface"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-endpoint-interface element defines a fully qualified
+            Java class that represents the Service Endpoint Interface of a
+            WSDL port.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="enable-mtom"
+                   type="javaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to enable or disable SOAP MTOM/XOP mechanism on the client
+            side for a port-component. 
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="mtom-threshold"
+                   type="javaee:xsdNonNegativeIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            When MTOM is enabled, binary data above this size in bytes
+            should be XOP encoded or sent as attachment. Default value is 0.
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="addressing"
+                   type="javaee:addressingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            This specifies the WS-Addressing requirements for a JAX-WS
+            web service. It corresponds to javax.xml.ws.soap.Addressing
+            annotation or its feature javax.xml.ws.soap.AddressingFeature.
+            
+            See the addressingType for more information.
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="respect-binding"
+                   type="javaee:respect-bindingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Corresponds to the javax.xml.ws.RespectBinding annotation
+            or its corresponding javax.xml.ws.RespectBindingFeature web
+            service feature. This is used to control whether a JAX-WS
+            implementation must respect/honor the contents of the
+            wsdl:binding in the WSDL that is associated with the service.
+            
+            Not to be specified for JAX-RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-component-link"
+                   type="javaee:string"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The port-component-link element links a port-component-ref
+            to a specific port-component required to be made available
+            by a service reference.
+            
+            The value of a port-component-link must be the
+            port-component-name of a port-component in the same module
+            or another module in the same application unit. The syntax
+            for specification follows the syntax defined for ejb-link
+            in the EJB 2.0 specification.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="handler-chainsType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The handler-chains element defines the handlerchains associated with this
+        service or service endpoint.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="handler-chain"
+                   type="javaee:handler-chainType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="handler-chainType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The handler-chain element defines the handlerchain. 
+        Handlerchain can be defined such that the handlers in the
+        handlerchain operate,all ports of a service, on a specific
+        port or on a list of protocol-bindings. The choice of elements
+        service-name-pattern, port-name-pattern and protocol-bindings
+        are used to specify whether the handlers in handler-chain are
+        for a service, port or protocol binding. If none of these 
+        choices are specified with the handler-chain element then the
+        handlers specified in the handler-chain will be applied on 
+        everything.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice minOccurs="0"
+                  maxOccurs="1">
+        <xsd:element name="service-name-pattern"
+                     type="javaee:qname-pattern"/>
+        <xsd:element name="port-name-pattern"
+                     type="javaee:qname-pattern"/>
+        <xsd:element name="protocol-bindings"
+                     type="javaee:protocol-bindingListType"/>
+      </xsd:choice>
+      <xsd:element name="handler"
+                   type="javaee:handlerType"
+                   minOccurs="1"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="protocol-bindingListType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the type used for specifying a list of
+        protocol-bindingType(s). For e.g.
+        
+        ##SOAP11_HTTP ##SOAP12_HTTP ##XML_HTTP
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:list itemType="javaee:protocol-bindingType"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="protocol-bindingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the type used for specifying the URI for the
+        protocol binding used by the port-component.  For
+        portability one could use one of the following tokens that
+        alias the standard binding types: 
+        
+        ##SOAP11_HTTP
+        ##SOAP11_HTTP_MTOM
+        ##SOAP12_HTTP
+        ##SOAP12_HTTP_MTOM
+        ##XML_HTTP
+        
+        Other specifications could define tokens that start with ##
+        to alias new standard binding URIs that are introduced.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:union memberTypes="xsd:anyURI javaee:protocol-URIAliasType"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="protocol-URIAliasType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the type that is used for specifying tokens that
+        start with ## which are used to alias existing standard
+        protocol bindings and support aliases for new standard
+        binding URIs that are introduced in future specifications.
+        
+        The following tokens alias the standard protocol binding
+        URIs:
+        
+        ##SOAP11_HTTP = "http://schemas.xmlsoap.org/wsdl/soap/http"
+        ##SOAP11_HTTP_MTOM = 
+        "http://schemas.xmlsoap.org/wsdl/soap/http?mtom=true"
+        ##SOAP12_HTTP = "http://www.w3.org/2003/05/soap/bindings/HTTP/"
+        ##SOAP12_HTTP_MTOM = 
+        "http://www.w3.org/2003/05/soap/bindings/HTTP/?mtom=true"
+        ##XML_HTTP = "http://www.w3.org/2004/08/wsdl/http"
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="##.+"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="qname-pattern">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is used to specify the QName pattern in the
+        attribute service-name-pattern and port-name-pattern in
+        the handler-chain element
+        
+        For example, the various forms acceptable here for
+        service-name-pattern attribute in handler-chain element
+        are :
+        
+        Exact Name: service-name-pattern="ns1:EchoService"
+        
+        	 In this case, handlers specified in this
+        	 handler-chain element will apply to all ports with
+        	 this exact service name. The namespace prefix must
+        	 have been declared in a namespace declaration
+        	 attribute in either the start-tag of the element
+        	 where the prefix is used or in an an ancestor 
+        	 element (i.e. an element in whose content the 
+        	 prefixed markup occurs)
+        	 
+        
+        Pattern : service-name-pattern="ns1:EchoService*"
+        
+        	 In this case, handlers specified in this
+        	 handler-chain element will apply to all ports whose
+        	 Service names are like EchoService1, EchoServiceFoo
+        	 etc. The namespace prefix must have been declared in
+        	 a namespace declaration attribute in either the
+        	 start-tag of the element where the prefix is used or
+        	 in an an ancestor element (i.e. an element in whose 
+        	 content the prefixed markup occurs)
+        
+        Wild Card : service-name-pattern="*"
+        
+        	In this case, handlers specified in this handler-chain
+        	element will apply to ports of all service names.
+        
+        The same can be applied to port-name attribute in
+        handler-chain element.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="\*|([\i-[:]][\c-[:]]*:)?[\i-[:]][\c-[:]]*\*?"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="addressingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This specifies the WS-Addressing requirements for a JAX-WS web service.
+        It corresponds to javax.xml.ws.soap.Addressing annotation or its
+        feature javax.xml.ws.soap.AddressingFeature.
+        
+        If the "enabled" element is "true", WS-Addressing is enabled.
+        It means that the endpoint supports WS-Addressing but does not require
+        its use. The default value for "enabled" is "true".
+        
+        If the WS-Addressing is enabled and the "required" element is "true",
+        it means that the endpoint requires WS-Addressing. The default value
+        for "required" is "false".
+        
+        If WS-Addressing is enabled, the "responses" element determines
+        if an endpoint requires the use of only anonymous responses,
+        or only non-anonymous responses, or all. The value of the "responses"
+        element must be one of the following:
+        
+        ANONYMOUS
+        NON_ANONYMOUS
+        ALL
+        
+        The default value for the "responses" is ALL.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="enabled"
+                   type="javaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="required"
+                   type="javaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="responses"
+                   type="javaee:addressing-responsesType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="addressing-responsesType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        If WS-Addressing is enabled, this type determines if an endpoint
+        requires the use of only anonymous responses, or only non-anonymous
+        responses, or all.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="ANONYMOUS"/>
+        <xsd:enumeration value="NON_ANONYMOUS"/>
+        <xsd:enumeration value="ALL"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="respect-bindingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Corresponds to the javax.xml.ws.RespectBinding annotation
+        or its corresponding javax.xml.ws.RespectBindingFeature web
+        service feature. This is used to control whether a JAX-WS
+        implementation must respect/honor the contents of the
+        wsdl:binding in the WSDL that is associated with the service.
+        
+        If the "enabled" element is "true", wsdl:binding in the
+        associated WSDL, if any, must be respected/honored.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="enabled"
+                   type="javaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="handlerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Declares the handler for a port-component, service-ref. Handlers can
+        access the init-param name/value pairs using the HandlerInfo interface.
+        
+        Used in: port-component, service-ref
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="handler-name"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the name of the handler. The name must be unique within the
+            module.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="handler-class"
+                   type="javaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines a fully qualified class name for the handler implementation.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="init-param"
+                   type="javaee:param-valueType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Not to be specified for JAX-WS runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="soap-header"
+                   type="javaee:xsdQNameType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the QName of a SOAP header that will be processed by the
+            handler.
+            
+            Not to be specified for JAX-WS runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="soap-role"
+                   type="javaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The soap-role element contains a SOAP actor definition that the
+            Handler will play as a role.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-name"
+                   type="javaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The port-name element defines the WSDL port-name that a
+            handler should be associated with. If port-name is not
+            specified, the handler is assumed to be associated with
+            all ports of the service.
+            
+            Not to be specified for JAX-WS runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:group name="service-refGroup">
+    <xsd:sequence>
+      <xsd:element name="service-ref"
+                   type="javaee:service-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:key name="service-ref_handler-name-key">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              Defines the name of the handler. The name must be unique
+              within the module.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="javaee:handler"/>
+          <xsd:field xpath="javaee:handler-name"/>
+        </xsd:key>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:group>
+
+</xsd:schema>

--- a/net.sf.eclipse.tomcat/src/net/sf/eclipse/tomcat/schemas/jsp_2_3.xsd
+++ b/net.sf.eclipse.tomcat/src/net/sf/eclipse/tomcat/schemas/jsp_2_3.xsd
@@ -1,0 +1,389 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.3">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+      
+      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
+      
+      The contents of this file are subject to the terms of either the GNU
+      General Public License Version 2 only ("GPL") or the Common Development
+      and Distribution License("CDDL") (collectively, the "License").  You
+      may not use this file except in compliance with the License.  You can
+      obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+      or packager/legal/LICENSE.txt.  See the License for the specific
+      language governing permissions and limitations under the License.
+      
+      When distributing the software, include this License Header Notice in each
+      file and include the License file at packager/legal/LICENSE.txt.
+      
+      GPL Classpath Exception:
+      Oracle designates this particular file as subject to the "Classpath"
+      exception as provided by Oracle in the GPL Version 2 section of the License
+      file that accompanied this code.
+      
+      Modifications:
+      If applicable, add the following below the License Header, with the fields
+      enclosed by brackets [] replaced by your own identifying information:
+      "Portions Copyright [year] [name of copyright owner]"
+      
+      Contributor(s):
+      If you wish your version of this file to be governed by only the CDDL or
+      only the GPL Version 2, indicate your decision by adding "[Contributor]
+      elects to include this software in this distribution under the [CDDL or GPL
+      Version 2] license."  If you don't indicate a single choice of license, a
+      recipient has the option to distribute your version of this file under
+      either the CDDL, the GPL Version 2 or to extend the choice of license to
+      its licensees as provided above.  However, if you add GPL Version 2 code
+      and therefore, elected the GPL Version 2 license, then the option applies
+      only if the new code is made subject to such option by the copyright
+      holder.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      This is the XML Schema for the JSP 2.3 deployment descriptor
+      types.  The JSP 2.3 schema contains all the special
+      structures and datatypes that are necessary to use JSP files
+      from a web application. 
+      
+      The contents of this schema is used by the web-common_3_1.xsd 
+      file to define JSP specific content. 
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Java EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="javaee_7.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jsp-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The jsp-configType is used to provide global configuration
+        information for the JSP files in a web application. It has
+        two subelements, taglib and jsp-property-group.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="taglib"
+                   type="javaee:taglibType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jsp-property-group"
+                   type="javaee:jsp-property-groupType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jsp-fileType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The jsp-file element contains the full path to a JSP file
+        within the web application beginning with a `/'.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:pathType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jsp-property-groupType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The jsp-property-groupType is used to group a number of
+        files so they can be given global property information.
+        All files so described are deemed to be JSP files.  The
+        following additional properties can be described:
+        
+        - Control whether EL is ignored.
+        - Control whether scripting elements are invalid.
+        - Indicate pageEncoding information.
+        - Indicate that a resource is a JSP document (XML).
+        - Prelude and Coda automatic includes.
+        - Control whether the character sequence #{ is allowed
+        when used as a String literal.
+        - Control whether template text containing only
+        whitespaces must be removed from the response output.
+        - Indicate the default contentType information.
+        - Indicate the default buffering model for JspWriter
+        - Control whether error should be raised for the use of
+        undeclared namespaces in a JSP page.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="url-pattern"
+                   type="javaee:url-patternType"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="el-ignored"
+                   type="javaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Can be used to easily set the isELIgnored
+            property of a group of JSP pages.  By default, the
+            EL evaluation is enabled for Web Applications using
+            a Servlet 2.4 or greater web.xml, and disabled
+            otherwise.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="page-encoding"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The valid values of page-encoding are those of the
+            pageEncoding page directive.  It is a
+            translation-time error to name different encodings
+            in the pageEncoding attribute of the page directive
+            of a JSP page and in a JSP configuration element
+            matching the page.  It is also a translation-time
+            error to name different encodings in the prolog
+            or text declaration of a document in XML syntax and
+            in a JSP configuration element matching the document.
+            It is legal to name the same encoding through
+            mulitple mechanisms.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="scripting-invalid"
+                   type="javaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Can be used to easily disable scripting in a
+            group of JSP pages.  By default, scripting is
+            enabled.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="is-xml"
+                   type="javaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            If true, denotes that the group of resources
+            that match the URL pattern are JSP documents,
+            and thus must be interpreted as XML documents.
+            If false, the resources are assumed to not
+            be JSP documents, unless there is another
+            property group that indicates otherwise.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="include-prelude"
+                   type="javaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The include-prelude element is a context-relative
+            path that must correspond to an element in the
+            Web Application.  When the element is present,
+            the given path will be automatically included (as
+            in an include directive) at the beginning of each
+            JSP page in this jsp-property-group.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="include-coda"
+                   type="javaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The include-coda element is a context-relative
+            path that must correspond to an element in the
+            Web Application.  When the element is present,
+            the given path will be automatically included (as
+            in an include directive) at the end of each
+            JSP page in this jsp-property-group.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="deferred-syntax-allowed-as-literal"
+                   type="javaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The character sequence #{ is reserved for EL expressions.
+            Consequently, a translation error occurs if the #{
+            character sequence is used as a String literal, unless
+            this element is enabled (true). Disabled (false) by
+            default.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="trim-directive-whitespaces"
+                   type="javaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Indicates that template text containing only whitespaces
+            must be removed from the response output. It has no
+            effect on JSP documents (XML syntax). Disabled (false)
+            by default.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="default-content-type"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The valid values of default-content-type are those of the
+            contentType page directive.  It specifies the default
+            response contentType if the page directive does not include
+            a contentType attribute.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="buffer"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The valid values of buffer are those of the
+            buffer page directive.  It specifies if buffering should be
+            used for the output to response, and if so, the size of the
+            buffer to use.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="error-on-undeclared-namespace"
+                   type="javaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The default behavior when a tag with unknown namespace is used
+            in a JSP page (regular syntax) is to silently ignore it.  If
+            set to true, then an error must be raised during the translation
+            time when an undeclared tag is used in a JSP page.  Disabled
+            (false) by default.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="taglibType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The taglibType defines the syntax for declaring in
+        the deployment descriptor that a tag library is
+        available to the application.  This can be done
+        to override implicit map entries from TLD files and
+        from the container.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="taglib-uri"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A taglib-uri element describes a URI identifying a
+            tag library used in the web application.  The body
+            of the taglib-uri element may be either an
+            absolute URI specification, or a relative URI.
+            There should be no entries in web.xml with the
+            same taglib-uri value.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="taglib-location"
+                   type="javaee:pathType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            the taglib-location element contains the location
+            (as a resource relative to the root of the web
+            application) where to find the Tag Library
+            Description file for the tag library.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/net.sf.eclipse.tomcat/src/net/sf/eclipse/tomcat/schemas/web-app_3_1.xsd
+++ b/net.sf.eclipse.tomcat/src/net/sf/eclipse/tomcat/schemas/web-app_3_1.xsd
@@ -1,0 +1,326 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="3.1">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+      
+      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
+      
+      The contents of this file are subject to the terms of either the GNU
+      General Public License Version 2 only ("GPL") or the Common Development
+      and Distribution License("CDDL") (collectively, the "License").  You
+      may not use this file except in compliance with the License.  You can
+      obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+      or packager/legal/LICENSE.txt.  See the License for the specific
+      language governing permissions and limitations under the License.
+      
+      When distributing the software, include this License Header Notice in each
+      file and include the License file at packager/legal/LICENSE.txt.
+      
+      GPL Classpath Exception:
+      Oracle designates this particular file as subject to the "Classpath"
+      exception as provided by Oracle in the GPL Version 2 section of the License
+      file that accompanied this code.
+      
+      Modifications:
+      If applicable, add the following below the License Header, with the fields
+      enclosed by brackets [] replaced by your own identifying information:
+      "Portions Copyright [year] [name of copyright owner]"
+      
+      Contributor(s):
+      If you wish your version of this file to be governed by only the CDDL or
+      only the GPL Version 2, indicate your decision by adding "[Contributor]
+      elects to include this software in this distribution under the [CDDL or GPL
+      Version 2] license."  If you don't indicate a single choice of license, a
+      recipient has the option to distribute your version of this file under
+      either the CDDL, the GPL Version 2 or to extend the choice of license to
+      its licensees as provided above.  However, if you add GPL Version 2 code
+      and therefore, elected the GPL Version 2 license, then the option applies
+      only if the new code is made subject to such option by the copyright
+      holder.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[[
+      This is the XML Schema for the Servlet 3.1 deployment descriptor.
+      The deployment descriptor must be named "WEB-INF/web.xml" in the
+      web application's war file.  All Servlet deployment descriptors
+      must indicate the web application schema by using the Java EE
+      namespace:
+      
+      http://xmlns.jcp.org/xml/ns/javaee 
+      
+      and by indicating the version of the schema by 
+      using the version element as shown below: 
+      
+      <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="..."
+      version="3.1"> 
+      ...
+      </web-app>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Java EE
+      namespace with the following location:
+      
+      http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Java EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="web-common_3_1.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="web-app"
+               type="javaee:web-appType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The web-app element is the root of the deployment
+        descriptor for a web application.  Note that the sub-elements
+        of this element can be in the arbitrary order. Because of
+        that, the multiplicity of the elements of distributable,
+        session-config, welcome-file-list, jsp-config, login-config,
+        and locale-encoding-mapping-list was changed from "?" to "*"
+        in this schema.  However, the deployment descriptor instance
+        file must not contain multiple elements of session-config,
+        jsp-config, and login-config. When there are multiple elements of
+        welcome-file-list or locale-encoding-mapping-list, the container
+        must concatenate the element contents.  The multiple occurence
+        of the element distributable is redundant and the container
+        treats that case exactly in the same way when there is only
+        one distributable. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="web-common-servlet-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The servlet element contains the name of a servlet.
+          The name must be unique within the web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:servlet"/>
+      <xsd:field xpath="javaee:servlet-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-filter-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The filter element contains the name of a filter.
+          The name must be unique within the web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:filter"/>
+      <xsd:field xpath="javaee:filter-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-ejb-local-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-local-ref-name element contains the name of an EJB
+          reference. The EJB reference is an entry in the web
+          application's environment and is relative to the
+          java:comp/env context.  The name must be unique within
+          the web application.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:ejb-local-ref"/>
+      <xsd:field xpath="javaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-ejb-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-ref-name element contains the name of an EJB
+          reference. The EJB reference is an entry in the web
+          application's environment and is relative to the
+          java:comp/env context.  The name must be unique within
+          the web application.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:ejb-ref"/>
+      <xsd:field xpath="javaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-resource-env-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The resource-env-ref-name element specifies the name of
+          a resource environment reference; its value is the
+          environment entry name used in the web application code.
+          The name is a JNDI name relative to the java:comp/env
+          context and must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:resource-env-ref"/>
+      <xsd:field xpath="javaee:resource-env-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-message-destination-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The message-destination-ref-name element specifies the name of
+          a message destination reference; its value is the
+          environment entry name used in the web application code.
+          The name is a JNDI name relative to the java:comp/env
+          context and must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:message-destination-ref"/>
+      <xsd:field xpath="javaee:message-destination-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-res-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The res-ref-name element specifies the name of a
+          resource manager connection factory reference.  The name
+          is a JNDI name relative to the java:comp/env context.
+          The name must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:resource-ref"/>
+      <xsd:field xpath="javaee:res-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-env-entry-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The env-entry-name element contains the name of a web
+          application's environment entry.  The name is a JNDI
+          name relative to the java:comp/env context.  The name
+          must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:env-entry"/>
+      <xsd:field xpath="javaee:env-entry-name"/>
+    </xsd:unique>
+    <xsd:key name="web-common-role-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          A role-name-key is specified to allow the references
+          from the security-role-refs.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:security-role"/>
+      <xsd:field xpath="javaee:role-name"/>
+    </xsd:key>
+    <xsd:keyref name="web-common-role-name-references"
+                refer="javaee:web-common-role-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The keyref indicates the references from
+          security-role-ref to a specified role-name.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="javaee:servlet/javaee:security-role-ref"/>
+      <xsd:field xpath="javaee:role-link"/>
+    </xsd:keyref>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="web-appType">
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="module-name"
+                   type="javaee:string"
+                   minOccurs="0"/>
+      <xsd:group ref="javaee:web-commonType"/>
+      <xsd:element name="deny-uncovered-http-methods"
+                   type="javaee:emptyType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            When specified, this element causes uncovered http methods
+            to be denied. For every url-pattern that is the target of a 
+            security-constrant, this element causes all HTTP methods that
+            are NOT covered (by a security constraint) at the url-pattern
+            to be denied.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="absolute-ordering"
+                   type="javaee:absoluteOrderingType"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="javaee:web-common-attributes"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="absoluteOrderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Please see section 8.2.2 of the specification for details.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="name"
+                   type="javaee:java-identifierType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="others"
+                   type="javaee:ordering-othersType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/net.sf.eclipse.tomcat/src/net/sf/eclipse/tomcat/schemas/web-common_3_1.xsd
+++ b/net.sf.eclipse.tomcat/src/net/sf/eclipse/tomcat/schemas/web-common_3_1.xsd
@@ -1,0 +1,1474 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:javaee="http://xmlns.jcp.org/xml/ns/javaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="3.1">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+      
+      Copyright (c) 2009-2013 Oracle and/or its affiliates. All rights reserved.
+      
+      The contents of this file are subject to the terms of either the GNU
+      General Public License Version 2 only ("GPL") or the Common Development
+      and Distribution License("CDDL") (collectively, the "License").  You
+      may not use this file except in compliance with the License.  You can
+      obtain a copy of the License at
+      https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+      or packager/legal/LICENSE.txt.  See the License for the specific
+      language governing permissions and limitations under the License.
+      
+      When distributing the software, include this License Header Notice in each
+      file and include the License file at packager/legal/LICENSE.txt.
+      
+      GPL Classpath Exception:
+      Oracle designates this particular file as subject to the "Classpath"
+      exception as provided by Oracle in the GPL Version 2 section of the License
+      file that accompanied this code.
+      
+      Modifications:
+      If applicable, add the following below the License Header, with the fields
+      enclosed by brackets [] replaced by your own identifying information:
+      "Portions Copyright [year] [name of copyright owner]"
+      
+      Contributor(s):
+      If you wish your version of this file to be governed by only the CDDL or
+      only the GPL Version 2, indicate your decision by adding "[Contributor]
+      elects to include this software in this distribution under the [CDDL or GPL
+      Version 2] license."  If you don't indicate a single choice of license, a
+      recipient has the option to distribute your version of this file under
+      either the CDDL, the GPL Version 2 or to extend the choice of license to
+      its licensees as provided above.  However, if you add GPL Version 2 code
+      and therefore, elected the GPL Version 2 license, then the option applies
+      only if the new code is made subject to such option by the copyright
+      holder.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[[
+      This is the common XML Schema for the Servlet 3.1 deployment descriptor.
+      This file is in turn used by web.xml and web-fragment.xml
+      web application's war file.  All Servlet deployment descriptors
+      must indicate the web common schema by using the Java EE
+      namespace:
+      
+      http://xmlns.jcp.org/xml/ns/javaee 
+      
+      and by indicating the version of the schema by 
+      using the version element as shown below: 
+      
+      <web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="..."
+      version="3.1"> 
+      ...
+      </web-app>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Java EE
+      namespace with the following location:
+      
+      http://xmlns.jcp.org/xml/ns/javaee/web-common_3_1.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Java EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="javaee_7.xsd"/>
+
+  <xsd:include schemaLocation="jsp_2_3.xsd"/>
+
+  <xsd:group name="web-commonType">
+    <xsd:choice>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="distributable"
+                   type="javaee:emptyType"/>
+      <xsd:element name="context-param"
+                   type="javaee:param-valueType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The context-param element contains the declaration
+            of a web application's servlet context
+            initialization parameters.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="filter"
+                   type="javaee:filterType"/>
+      <xsd:element name="filter-mapping"
+                   type="javaee:filter-mappingType"/>
+      <xsd:element name="listener"
+                   type="javaee:listenerType"/>
+      <xsd:element name="servlet"
+                   type="javaee:servletType"/>
+      <xsd:element name="servlet-mapping"
+                   type="javaee:servlet-mappingType"/>
+      <xsd:element name="session-config"
+                   type="javaee:session-configType"/>
+      <xsd:element name="mime-mapping"
+                   type="javaee:mime-mappingType"/>
+      <xsd:element name="welcome-file-list"
+                   type="javaee:welcome-file-listType"/>
+      <xsd:element name="error-page"
+                   type="javaee:error-pageType"/>
+      <xsd:element name="jsp-config"
+                   type="javaee:jsp-configType"/>
+      <xsd:element name="security-constraint"
+                   type="javaee:security-constraintType"/>
+      <xsd:element name="login-config"
+                   type="javaee:login-configType"/>
+      <xsd:element name="security-role"
+                   type="javaee:security-roleType"/>
+      <xsd:group ref="javaee:jndiEnvironmentRefsGroup"/>
+      <xsd:element name="message-destination"
+                   type="javaee:message-destinationType"/>
+      <xsd:element name="locale-encoding-mapping-list"
+                   type="javaee:locale-encoding-mapping-listType"/>
+    </xsd:choice>
+  </xsd:group>
+
+  <xsd:attributeGroup name="web-common-attributes">
+    <xsd:attribute name="version"
+                   type="javaee:web-app-versionType"
+                   use="required"/>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="metadata-complete"
+                   type="xsd:boolean">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The metadata-complete attribute defines whether this
+          deployment descriptor and other related deployment
+          descriptors for this module (e.g., web service
+          descriptors) are complete, or whether the class
+          files available to this module and packaged with
+          this application should be examined for annotations
+          that specify deployment information.
+          
+          If metadata-complete is set to "true", the deployment
+          tool must ignore any annotations that specify deployment
+          information, which might be present in the class files
+          of the application.
+          
+          If metadata-complete is not specified or is set to
+          "false", the deployment tool must examine the class
+          files of the application for annotations, as
+          specified by the specifications.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:attributeGroup>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="auth-constraintType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The auth-constraintType indicates the user roles that
+        should be permitted access to this resource
+        collection. The role-name used here must either correspond
+        to the role-name of one of the security-role elements
+        defined for this web application, or be the specially
+        reserved role-name "*" that is a compact syntax for
+        indicating all roles in the web application. If both "*"
+        and rolenames appear, the container interprets this as all
+        roles.  If no roles are defined, no user is allowed access
+        to the portion of the web application described by the
+        containing security-constraint.  The container matches
+        role names case sensitively when determining access.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="role-name"
+                   type="javaee:role-nameType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="auth-methodType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The auth-methodType is used to configure the authentication
+        mechanism for the web application. As a prerequisite to
+        gaining access to any web resources which are protected by
+        an authorization constraint, a user must have authenticated
+        using the configured mechanism. Legal values are "BASIC",
+        "DIGEST", "FORM", "CLIENT-CERT", or a vendor-specific
+        authentication scheme.
+        
+        Used in: login-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="dispatcherType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The dispatcher has five legal values: FORWARD, REQUEST,
+        INCLUDE, ASYNC, and ERROR.
+        
+        A value of FORWARD means the Filter will be applied under
+        RequestDispatcher.forward() calls.
+        A value of REQUEST means the Filter will be applied under
+        ordinary client calls to the path or servlet.
+        A value of INCLUDE means the Filter will be applied under
+        RequestDispatcher.include() calls.
+        A value of ASYNC means the Filter will be applied under
+        calls dispatched from an AsyncContext.
+        A value of ERROR means the Filter will be applied under the
+        error page mechanism.
+        
+        The absence of any dispatcher elements in a filter-mapping
+        indicates a default of applying filters only under ordinary
+        client calls to the path or servlet.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="FORWARD"/>
+        <xsd:enumeration value="INCLUDE"/>
+        <xsd:enumeration value="REQUEST"/>
+        <xsd:enumeration value="ASYNC"/>
+        <xsd:enumeration value="ERROR"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="error-codeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The error-code contains an HTTP error code, ex: 404
+        
+        Used in: error-page
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:xsdPositiveIntegerType">
+        <xsd:pattern value="\d{3}"/>
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="error-pageType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The error-pageType contains a mapping between an error code
+        or exception type to the path of a resource in the web
+        application.
+        
+        Error-page declarations using the exception-type element in
+        the deployment descriptor must be unique up to the class name of
+        the exception-type. Similarly, error-page declarations using the
+        error-code element must be unique in the deployment descriptor
+        up to the status code.
+        
+        If an error-page element in the deployment descriptor does not
+        contain an exception-type or an error-code element, the error
+        page is a default error page. 
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice minOccurs="0"
+                  maxOccurs="1">
+        <xsd:element name="error-code"
+                     type="javaee:error-codeType"/>
+        <xsd:element name="exception-type"
+                     type="javaee:fully-qualified-classType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The exception-type contains a fully qualified class
+              name of a Java exception type.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+      <xsd:element name="location"
+                   type="javaee:war-pathType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The location element contains the location of the
+            resource in the web application relative to the root of
+            the web application. The value of the location must have
+            a leading `/'.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="filterType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The filterType is used to declare a filter in the web
+        application. The filter is mapped to either a servlet or a
+        URL pattern in the filter-mapping element, using the
+        filter-name value to reference. Filters can access the
+        initialization parameters declared in the deployment
+        descriptor at runtime via the FilterConfig interface.
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="filter-name"
+                   type="javaee:filter-nameType"/>
+      <xsd:element name="filter-class"
+                   type="javaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The fully qualified classname of the filter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="async-supported"
+                   type="javaee:true-falseType"
+                   minOccurs="0"/>
+      <xsd:element name="init-param"
+                   type="javaee:param-valueType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The init-param element contains a name/value pair as
+            an initialization param of a servlet filter
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="filter-mappingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Declaration of the filter mappings in this web
+        application is done by using filter-mappingType. 
+        The container uses the filter-mapping
+        declarations to decide which filters to apply to a request,
+        and in what order. The container matches the request URI to
+        a Servlet in the normal way. To determine which filters to
+        apply it matches filter-mapping declarations either on
+        servlet-name, or on url-pattern for each filter-mapping
+        element, depending on which style is used. The order in
+        which filters are invoked is the order in which
+        filter-mapping declarations that match a request URI for a
+        servlet appear in the list of filter-mapping elements.The
+        filter-name value must be the value of the filter-name
+        sub-elements of one of the filter declarations in the
+        deployment descriptor.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="filter-name"
+                   type="javaee:filter-nameType"/>
+      <xsd:choice minOccurs="1"
+                  maxOccurs="unbounded">
+        <xsd:element name="url-pattern"
+                     type="javaee:url-patternType"/>
+        <xsd:element name="servlet-name"
+                     type="javaee:servlet-nameType"/>
+      </xsd:choice>
+      <xsd:element name="dispatcher"
+                   type="javaee:dispatcherType"
+                   minOccurs="0"
+                   maxOccurs="5"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="nonEmptyStringType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type defines a string which contains at least one
+        character.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="filter-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The logical name of the filter is declare
+        by using filter-nameType. This name is used to map the
+        filter.  Each filter name is unique within the web
+        application.
+        
+        Used in: filter, filter-mapping
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="javaee:nonEmptyStringType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="form-login-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The form-login-configType specifies the login and error
+        pages that should be used in form based login. If form based
+        authentication is not used, these elements are ignored.
+        
+        Used in: login-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="form-login-page"
+                   type="javaee:war-pathType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The form-login-page element defines the location in the web
+            app where the page that can be used for login can be
+            found.  The path begins with a leading / and is interpreted
+            relative to the root of the WAR.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="form-error-page"
+                   type="javaee:war-pathType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The form-error-page element defines the location in
+            the web app where the error page that is displayed
+            when login is not successful can be found. 
+            The path begins with a leading / and is interpreted
+            relative to the root of the WAR.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="http-methodType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        A HTTP method type as defined in HTTP 1.1 section 2.2.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="[!-~-[\(\)&#60;&#62;@,;:&#34;/\[\]?=\{\}\\\p{Z}]]+"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="load-on-startupType">
+    <xsd:union memberTypes="javaee:null-charType xsd:integer"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="null-charType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value=""/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="login-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The login-configType is used to configure the authentication
+        method that should be used, the realm name that should be
+        used for this application, and the attributes that are
+        needed by the form login mechanism.
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="auth-method"
+                   type="javaee:auth-methodType"
+                   minOccurs="0"/>
+      <xsd:element name="realm-name"
+                   type="javaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The realm name element specifies the realm name to
+            use in HTTP Basic authorization.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="form-login-config"
+                   type="javaee:form-login-configType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="mime-mappingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The mime-mappingType defines a mapping between an extension
+        and a mime type.
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The extension element contains a string describing an
+          extension. example: "txt"
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:element name="extension"
+                   type="javaee:string"/>
+      <xsd:element name="mime-type"
+                   type="javaee:mime-typeType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="mime-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The mime-typeType is used to indicate a defined mime type.
+        
+        Example:
+        "text/plain"
+        
+        Used in: mime-mapping
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:pattern value="[^\p{Cc}^\s]+/[^\p{Cc}^\s]+"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-constraintType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The security-constraintType is used to associate
+        security constraints with one or more web resource
+        collections
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="display-name"
+                   type="javaee:display-nameType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="web-resource-collection"
+                   type="javaee:web-resource-collectionType"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="auth-constraint"
+                   type="javaee:auth-constraintType"
+                   minOccurs="0"/>
+      <xsd:element name="user-data-constraint"
+                   type="javaee:user-data-constraintType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="servletType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The servletType is used to declare a servlet.
+        It contains the declarative data of a
+        servlet. If a jsp-file is specified and the load-on-startup
+        element is present, then the JSP should be precompiled and
+        loaded.
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="javaee:descriptionGroup"/>
+      <xsd:element name="servlet-name"
+                   type="javaee:servlet-nameType"/>
+      <xsd:choice minOccurs="0"
+                  maxOccurs="1">
+        <xsd:element name="servlet-class"
+                     type="javaee:fully-qualified-classType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The servlet-class element contains the fully
+              qualified class name of the servlet.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="jsp-file"
+                     type="javaee:jsp-fileType"/>
+      </xsd:choice>
+      <xsd:element name="init-param"
+                   type="javaee:param-valueType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="load-on-startup"
+                   type="javaee:load-on-startupType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The load-on-startup element indicates that this
+            servlet should be loaded (instantiated and have
+            its init() called) on the startup of the web
+            application. The optional contents of these
+            element must be an integer indicating the order in
+            which the servlet should be loaded. If the value
+            is a negative integer, or the element is not
+            present, the container is free to load the servlet
+            whenever it chooses. If the value is a positive
+            integer or 0, the container must load and
+            initialize the servlet as the application is
+            deployed. The container must guarantee that
+            servlets marked with lower integers are loaded
+            before servlets marked with higher integers. The
+            container may choose the order of loading of
+            servlets with the same load-on-start-up value.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="enabled"
+                   type="javaee:true-falseType"
+                   minOccurs="0"/>
+      <xsd:element name="async-supported"
+                   type="javaee:true-falseType"
+                   minOccurs="0"/>
+      <xsd:element name="run-as"
+                   type="javaee:run-asType"
+                   minOccurs="0"/>
+      <xsd:element name="security-role-ref"
+                   type="javaee:security-role-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="multipart-config"
+                   type="javaee:multipart-configType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="servlet-mappingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The servlet-mappingType defines a mapping between a
+        servlet and a url pattern. 
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="servlet-name"
+                   type="javaee:servlet-nameType"/>
+      <xsd:element name="url-pattern"
+                   type="javaee:url-patternType"
+                   minOccurs="1"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="servlet-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The servlet-name element contains the canonical name of the
+        servlet. Each servlet name is unique within the web
+        application.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="javaee:nonEmptyStringType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="session-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The session-configType defines the session parameters
+        for this web application.
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="session-timeout"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The session-timeout element defines the default
+            session timeout interval for all sessions created
+            in this web application. The specified timeout
+            must be expressed in a whole number of minutes.
+            If the timeout is 0 or less, the container ensures
+            the default behaviour of sessions is never to time
+            out. If this element is not specified, the container
+            must set its default timeout period.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="cookie-config"
+                   type="javaee:cookie-configType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The cookie-config element defines the configuration of the
+            session tracking cookies created by this web application.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="tracking-mode"
+                   type="javaee:tracking-modeType"
+                   minOccurs="0"
+                   maxOccurs="3">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The tracking-mode element defines the tracking modes
+            for sessions created by this web application
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cookie-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The cookie-configType defines the configuration for the
+        session tracking cookies of this web application.
+        
+        Used in: session-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="javaee:cookie-nameType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name that will be assigned to any session tracking
+            cookies created by this web application.
+            The default is JSESSIONID
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="domain"
+                   type="javaee:cookie-domainType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The domain name that will be assigned to any session tracking
+            cookies created by this web application.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="path"
+                   type="javaee:cookie-pathType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The path that will be assigned to any session tracking
+            cookies created by this web application.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="comment"
+                   type="javaee:cookie-commentType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The comment that will be assigned to any session tracking
+            cookies created by this web application.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="http-only"
+                   type="javaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Specifies whether any session tracking cookies created 
+            by this web application will be marked as HttpOnly
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="secure"
+                   type="javaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Specifies whether any session tracking cookies created 
+            by this web application will be marked as secure.
+            When true, all session tracking cookies must be marked
+            as secure independent of the nature of the request that
+            initiated the corresponding session.
+            When false, the session cookie should only be marked secure
+            if the request that initiated the session was secure.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-age"
+                   type="javaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The lifetime (in seconds) that will be assigned to any
+            session tracking cookies created by this web application.
+            Default is -1
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cookie-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The name that will be assigned to any session tracking
+        cookies created by this web application.
+        The default is JSESSIONID
+        
+        Used in: cookie-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="javaee:nonEmptyStringType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cookie-domainType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The domain name that will be assigned to any session tracking
+        cookies created by this web application.
+        
+        Used in: cookie-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="javaee:nonEmptyStringType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cookie-pathType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The path that will be assigned to any session tracking
+        cookies created by this web application.
+        
+        Used in: cookie-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="javaee:nonEmptyStringType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cookie-commentType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The comment that will be assigned to any session tracking
+        cookies created by this web application.
+        
+        Used in: cookie-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="javaee:nonEmptyStringType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tracking-modeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The tracking modes for sessions created by this web
+        application
+        
+        Used in: session-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="COOKIE"/>
+        <xsd:enumeration value="URL"/>
+        <xsd:enumeration value="SSL"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="transport-guaranteeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The transport-guaranteeType specifies that the communication
+        between client and server should be NONE, INTEGRAL, or
+        CONFIDENTIAL. NONE means that the application does not
+        require any transport guarantees. A value of INTEGRAL means
+        that the application requires that the data sent between the
+        client and server be sent in such a way that it can't be
+        changed in transit. CONFIDENTIAL means that the application
+        requires that the data be transmitted in a fashion that
+        prevents other entities from observing the contents of the
+        transmission. In most cases, the presence of the INTEGRAL or
+        CONFIDENTIAL flag will indicate that the use of SSL is
+        required.
+        
+        Used in: user-data-constraint
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:enumeration value="NONE"/>
+        <xsd:enumeration value="INTEGRAL"/>
+        <xsd:enumeration value="CONFIDENTIAL"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="user-data-constraintType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The user-data-constraintType is used to indicate how
+        data communicated between the client and container should be
+        protected.
+        
+        Used in: security-constraint
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="transport-guarantee"
+                   type="javaee:transport-guaranteeType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="war-pathType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The elements that use this type designate a path starting
+        with a "/" and interpreted relative to the root of a WAR
+        file.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="javaee:string">
+        <xsd:pattern value="/.*"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:simpleType name="web-app-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type contains the recognized versions of
+        web-application supported. It is used to designate the
+        version of the web application.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="3.1"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="web-resource-collectionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The web-resource-collectionType is used to identify the
+        resources and HTTP methods on those resources to which a
+        security constraint applies. If no HTTP methods are specified,
+        then the security constraint applies to all HTTP methods.
+        If HTTP methods are specified by http-method-omission
+        elements, the security constraint applies to all methods
+        except those identified in the collection.
+        http-method-omission and http-method elements are never
+        mixed in the same collection. 
+        
+        Used in: security-constraint
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="web-resource-name"
+                   type="javaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The web-resource-name contains the name of this web
+            resource collection.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="description"
+                   type="javaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="url-pattern"
+                   type="javaee:url-patternType"
+                   maxOccurs="unbounded"/>
+      <xsd:choice minOccurs="0"
+                  maxOccurs="1">
+        <xsd:element name="http-method"
+                     type="javaee:http-methodType"
+                     minOccurs="1"
+                     maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              Each http-method names an HTTP method to which the
+              constraint applies.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="http-method-omission"
+                     type="javaee:http-methodType"
+                     minOccurs="1"
+                     maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              Each http-method-omission names an HTTP method to
+              which the constraint does not apply.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="welcome-file-listType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The welcome-file-list contains an ordered list of welcome
+        files elements.
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="welcome-file"
+                   type="xsd:string"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The welcome-file element contains file name to use
+            as a default welcome file, such as index.html
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="localeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The localeType defines valid locale defined by ISO-639-1
+        and ISO-3166.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="[a-z]{2}(_|-)?([\p{L}\-\p{Nd}]{2})?"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="encodingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The encodingType defines IANA character sets.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="[^\s]+"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="locale-encoding-mapping-listType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The locale-encoding-mapping-list contains one or more
+        locale-encoding-mapping(s).
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="locale-encoding-mapping"
+                   type="javaee:locale-encoding-mappingType"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="locale-encoding-mappingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The locale-encoding-mapping contains locale name and
+        encoding name. The locale name must be either "Language-code",
+        such as "ja", defined by ISO-639 or "Language-code_Country-code",
+        such as "ja_JP".  "Country code" is defined by ISO-3166.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="locale"
+                   type="javaee:localeType"/>
+      <xsd:element name="encoding"
+                   type="javaee:encodingType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ordering-othersType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This element indicates that the ordering sub-element in which
+        it was placed should take special action regarding the ordering
+        of this application resource relative to other application
+        configuration resources.
+        See section 8.2.2 of the specification for details.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="multipart-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This element specifies configuration information related to the
+        handling of multipart/form-data requests.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="location"
+                   type="javaee:string"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The directory location where uploaded files will be stored
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-file-size"
+                   type="xsd:long"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The maximum size limit of uploaded files
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-request-size"
+                   type="xsd:long"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The maximum size limit of multipart/form-data requests
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="file-size-threshold"
+                   type="xsd:integer"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The size threshold after which an uploaded file will be
+            written to disk
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
This PR makes the Tomcat plugin add the web.xml 3.1 schemas to the Eclipse XML Catalog.
From a user perspective, this allows a user to create such a web.xml via File/New.../Other/XML File, then select "Create XML File from an XML schema file" , and then select the correct schema.
Additionally, the user can now validate the web.xml file against this schema.

Note the following: The changes in MANIFEST.MF, and plugin.xml introduce a dependency to the plugin "org.eclipse.wst.xml.core", which may need to be installed as a dependency. I do not have sufficient Eclipse knowledge to determine, if, and how, this dependency can be made optional.
  